### PR TITLE
replace ZYDIS_ADDRESS_WIDTH_64 with ZYDIS_STACK_WIDTH_64

### DIFF
--- a/src/e9tool/e9x86_64.cpp
+++ b/src/e9tool/e9x86_64.cpp
@@ -43,11 +43,11 @@ static ZydisFormatter formatter;
 static void initDisassembler(void)
 {
     ZyanStatus result = ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64,
-        ZYDIS_ADDRESS_WIDTH_64);
+        ZYDIS_STACK_WIDTH_64);
     if (!ZYAN_SUCCESS(result))
         error("failed to initialize disassembler decoder");
     result = ZydisDecoderInit(&decoder_minimal, ZYDIS_MACHINE_MODE_LONG_64,
-        ZYDIS_ADDRESS_WIDTH_64);
+        ZYDIS_STACK_WIDTH_64);
     if (!ZYAN_SUCCESS(result))
         error("failed to initialize disassembler decoder");
     (void)ZydisDecoderEnableMode(&decoder_minimal, ZYDIS_DECODER_MODE_MINIMAL,


### PR DESCRIPTION
Zydis  replaces _ZYDIS_ADDRESS_WIDTH_64_ with _ZYDIS_STACK_WIDTH_64_ in [this commit](https://github.com/zyantific/zydis/commit/99a22d85b9ff41c906d3f3adb175b57d0a7af905).

Using _ZYDIS_ADDRESS_WIDTH_64_ causes compiling error (See #30).