### PR TITLE
Fix a copy and paste error in e9tool.h

### DIFF
--- a/src/e9tool/e9tool.h
+++ b/src/e9tool/e9tool.h
@@ -2173,7 +2173,7 @@ struct InstrInfo
     }
     uint8_t getSIB() const
     {
-        return (hasMODRM()? data[encoding.offset.sib]: 0);
+        return (hasSIB()? data[encoding.offset.sib]: 0);
     }
     int32_t getDISP() const
     {


### PR DESCRIPTION
getSIB should check hasSIB instead of hasMODRM