### PR TITLE
add hopper in projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Some other projects that use E9Patch include:
   [AFL](https://github.com/google/AFL) instrumentation into binaries.
 * [E9Syscall](https://github.com/GJDuck/e9syscall): System call
   interception using static binary rewriting of `libc.so`.
-* [Hopper](https://github.com/FuzzAnything/hopper): Automatical fuzzing test
+* [Hopper](https://github.com/FuzzAnything/hopper): Automatic fuzzing test
   cases generation for libraries.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Some other projects that use E9Patch include:
   [AFL](https://github.com/google/AFL) instrumentation into binaries.
 * [E9Syscall](https://github.com/GJDuck/e9syscall): System call
   interception using static binary rewriting of `libc.so`.
+* [Hopper](https://github.com/FuzzAnything/hopper): Automatical fuzzing test
+  cases generation for libraries.
 
 ## Documentation
 


### PR DESCRIPTION
Hi GJDuck,

We have used E9patch for instrumentation in [Hopper](https://github.com/FuzzAnything/hopper)'s implementation. Thank you for your great work in providing E9patch. Would you consider adding Hopper to the project list?

Thanks.