### PR TITLE
set -e for e9compile.sh

### DIFF
--- a/e9compile.sh
+++ b/e9compile.sh
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set -e
+
 if [ -t 1 ]
 then
     RED="\033[31m"
@@ -95,8 +97,7 @@ then
     exit 1
 fi
 
-RELOCS=`readelf -r "$BASENAME" | head -n 10 | grep 'R_X86_64_'`
-if [ ! -z "$RELOCS" ]
+if readelf -r "$BASENAME" | head -n 10 | grep -q 'R_X86_64_'
 then
     echo >&2
     echo "${RED}warning${OFF}: the generated file (${YELLOW}$BASENAME${OFF}) contains relocations" >&2


### PR DESCRIPTION
It is easier to debug when the script does not fall through errors.

The grep invocation is moved inside the predicate to not fail when there is no match.