### PR TITLE
Allow passing installation prefix to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@
 # BUILD COMMON
 #########################################################################
 
+PREFIX ?= /usr
 CXXFLAGS ?= -march=native
 CXXFLAGS += -std=c++11 -Wall -Wno-reorder -fPIC -pie \
-    -DVERSION=$(shell cat VERSION) -Wl,-rpath=/usr/share/e9tool/lib/
+    -DVERSION=$(shell cat VERSION) -Wl,-rpath=$(PREFIX)/share/e9tool/lib/
 
 E9PATCH_OBJS=\
     src/e9patch/e9CFR.o \
@@ -90,62 +91,62 @@ contrib/libdw/libdw.a:
 	(cd contrib/libdw/; make)
 
 install: all
-	install -d "$(DESTDIR)/usr/bin"
-	install -m 755 e9patch "$(DESTDIR)/usr/bin/e9patch"
-	install -m 755 e9tool "$(DESTDIR)/usr/bin/e9tool"
-	install -m 755 e9compile.sh "$(DESTDIR)/usr/bin/e9compile"
+	install -d "$(DESTDIR)$(PREFIX)/bin"
+	install -m 755 e9patch "$(DESTDIR)$(PREFIX)/bin/e9patch"
+	install -m 755 e9tool "$(DESTDIR)$(PREFIX)/bin/e9tool"
+	install -m 755 e9compile.sh "$(DESTDIR)$(PREFIX)/bin/e9compile"
 	sed \
-	    -e 's#-I examples#-I /usr/share/e9compile/include#g' e9compile.sh > \
-	    "$(DESTDIR)/usr/bin/e9compile"
-	chmod 555 "$(DESTDIR)/usr/bin/e9compile"
-	install -d "$(DESTDIR)/usr/share/doc/e9patch/"
+	    -e 's#-I examples#-I $(PREFIX)/share/e9compile/include#g' e9compile.sh > \
+	    "$(DESTDIR)$(PREFIX)/bin/e9compile"
+	chmod 555 "$(DESTDIR)$(PREFIX)/bin/e9compile"
+	install -d "$(DESTDIR)$(PREFIX)/share/doc/e9patch/"
 	sed \
-	    -e 's#https://github.com/GJDuck/e9patch/blob/master/doc/e9tool-user-guide.md#file:///usr/share/doc/e9tool/e9tool-user-guide.html#g' \
-	    -e 's#https://github.com/GJDuck/e9patch/tree/master/examples#file:///usr/share/e9tool/examples#g' \
-		doc/e9patch-programming-guide.md | markdown > \
-	    "$(DESTDIR)/usr/share/doc/e9patch/e9patch-programming-guide.html"
-	install -m 444 LICENSE "$(DESTDIR)/usr/share/doc/e9patch/LICENSE"
-	install -d "$(DESTDIR)/usr/share/doc/e9tool/"
+	    -e 's#https://github.com/GJDuck/e9patch/blob/master/doc/e9tool-user-guide.md#file://$(PREFIX)/share/doc/e9tool/e9tool-user-guide.html#g' \
+	    -e 's#https://github.com/GJDuck/e9patch/tree/master/examples#file://$(PREFIX)/share/e9tool/examples#g' \
+	    doc/e9patch-programming-guide.md | markdown > \
+	    "$(DESTDIR)$(PREFIX)/share/doc/e9patch/e9patch-programming-guide.html"
+	install -m 444 LICENSE "$(DESTDIR)$(PREFIX)/share/doc/e9patch/LICENSE"
+	install -d "$(DESTDIR)$(PREFIX)/share/doc/e9tool/"
 	sed \
-        -e 's#https://github.com/GJDuck/e9patch/blob/master/doc/e9patch-programming-guide.md#file:///usr/share/doc/e9patch/e9patch-programming-guide.html#g' \
-        doc/e9tool-user-guide.md | markdown > \
-        "$(DESTDIR)/usr/share/doc/e9tool/e9tool-user-guide.html"
-	install -m 444 LICENSE "$(DESTDIR)/usr/share/doc/e9tool/LICENSE"
-	install -Dm 444 src/e9tool/e9tool.h "$(DESTDIR)/usr/include/e9tool/e9tool.h"
-	install -Dm 444 src/e9tool/e9plugin.h "$(DESTDIR)/usr/include/e9tool/e9plugin.h"
-	install -d "$(DESTDIR)/usr/share/e9tool/examples/"
-	install -m 444 examples/bounds.c "$(DESTDIR)/usr/share/e9tool/examples/bounds.c"
+	    -e 's#https://github.com/GJDuck/e9patch/blob/master/doc/e9patch-programming-guide.md#file://$(PREFIX)/share/doc/e9patch/e9patch-programming-guide.html#g' \
+	    doc/e9tool-user-guide.md | markdown > \
+	    "$(DESTDIR)$(PREFIX)/share/doc/e9tool/e9tool-user-guide.html"
+	install -m 444 LICENSE "$(DESTDIR)$(PREFIX)/share/doc/e9tool/LICENSE"
+	install -Dm 444 src/e9tool/e9tool.h "$(DESTDIR)$(PREFIX)/include/e9tool/e9tool.h"
+	install -Dm 444 src/e9tool/e9plugin.h "$(DESTDIR)$(PREFIX)/include/e9tool/e9plugin.h"
+	install -d "$(DESTDIR)$(PREFIX)/share/e9tool/examples/"
+	install -m 444 examples/bounds.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/bounds.c"
 	sed \
-	    -e 's#\./e9compile.sh examples/bounds.c#e9compile /usr/share/e9tool/examples/bounds.c#' \
+	    -e 's#\./e9compile.sh examples/bounds.c#e9compile $(PREFIX)/share/e9tool/examples/bounds.c#' \
 	    -e 's#\./e9tool#e9tool#' \
-        examples/bounds.sh > \
-	    "$(DESTDIR)/usr/share/e9tool/examples/bounds.sh"
-	chmod 555 "$(DESTDIR)/usr/share/e9tool/examples/bounds.sh"
-	install -m 444 examples/cfi.c "$(DESTDIR)/usr/share/e9tool/examples/cfi.c"
-	install -m 444 examples/count.c "$(DESTDIR)/usr/share/e9tool/examples/count.c"
-	install -m 444 examples/cov.c "$(DESTDIR)/usr/share/e9tool/examples/cov.c"
-	install -m 444 examples/delay.c "$(DESTDIR)/usr/share/e9tool/examples/delay.c"
-	install -m 444 examples/hello.c "$(DESTDIR)/usr/share/e9tool/examples/hello.c"
-	install -m 444 examples/limit.c "$(DESTDIR)/usr/share/e9tool/examples/limit.c"
-	install -m 444 examples/nop.c "$(DESTDIR)/usr/share/e9tool/examples/nop.c"
-	install -m 444 examples/print.c "$(DESTDIR)/usr/share/e9tool/examples/print.c"
-	install -m 444 examples/printf.c "$(DESTDIR)/usr/share/e9tool/examples/printf.c"
-	install -m 444 examples/skip.c "$(DESTDIR)/usr/share/e9tool/examples/skip.c"
-	install -m 444 examples/state.c "$(DESTDIR)/usr/share/e9tool/examples/state.c"
-	install -m 444 examples/trap.c "$(DESTDIR)/usr/share/e9tool/examples/trap.c"
-	install -m 444 examples/win64_demo.c "$(DESTDIR)/usr/share/e9tool/examples/win64_demo.c"
-	install -d "$(DESTDIR)/usr/share/e9tool/examples/plugins/"
-	install -m 444 examples/plugins/example.cpp "$(DESTDIR)/usr/share/e9tool/examples/plugins/example.cpp"
-	install -d "$(DESTDIR)/usr/share/e9compile/include/"
-	install -m 444 examples/stdlib.c "$(DESTDIR)/usr/share/e9compile/include/stdlib.c"
-	install -m 444 src/e9patch/e9loader.h "$(DESTDIR)/usr/share/e9compile/include/e9loader.h"
-	install -d "$(DESTDIR)/usr/share/man/man1/"
-	gzip --stdout doc/e9patch.1 > "$(DESTDIR)/usr/share/man/man1/e9patch.1.gz"
-	chmod 444 "$(DESTDIR)/usr/share/man/man1/e9patch.1.gz"
-	gzip --stdout doc/e9tool.1 > "$(DESTDIR)/usr/share/man/man1/e9tool.1.gz"
-	chmod 444 "$(DESTDIR)/usr/share/man/man1/e9tool.1.gz"
-	gzip --stdout doc/e9compile.1 > "$(DESTDIR)/usr/share/man/man1/e9compile.1.gz"
-	chmod 444 "$(DESTDIR)/usr/share/man/man1/e9compile.1.gz"
+	    examples/bounds.sh > \
+	    "$(DESTDIR)$(PREFIX)/share/e9tool/examples/bounds.sh"
+	chmod 555 "$(DESTDIR)$(PREFIX)/share/e9tool/examples/bounds.sh"
+	install -m 444 examples/cfi.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/cfi.c"
+	install -m 444 examples/count.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/count.c"
+	install -m 444 examples/cov.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/cov.c"
+	install -m 444 examples/delay.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/delay.c"
+	install -m 444 examples/hello.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/hello.c"
+	install -m 444 examples/limit.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/limit.c"
+	install -m 444 examples/nop.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/nop.c"
+	install -m 444 examples/print.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/print.c"
+	install -m 444 examples/printf.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/printf.c"
+	install -m 444 examples/skip.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/skip.c"
+	install -m 444 examples/state.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/state.c"
+	install -m 444 examples/trap.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/trap.c"
+	install -m 444 examples/win64_demo.c "$(DESTDIR)$(PREFIX)/share/e9tool/examples/win64_demo.c"
+	install -d "$(DESTDIR)$(PREFIX)/share/e9tool/examples/plugins/"
+	install -m 444 examples/plugins/example.cpp "$(DESTDIR)$(PREFIX)/share/e9tool/examples/plugins/example.cpp"
+	install -d "$(DESTDIR)$(PREFIX)/share/e9compile/include/"
+	install -m 444 examples/stdlib.c "$(DESTDIR)$(PREFIX)/share/e9compile/include/stdlib.c"
+	install -m 444 src/e9patch/e9loader.h "$(DESTDIR)$(PREFIX)/share/e9compile/include/e9loader.h"
+	install -d "$(DESTDIR)$(PREFIX)/share/man/man1/"
+	gzip --stdout doc/e9patch.1 > "$(DESTDIR)$(PREFIX)/share/man/man1/e9patch.1.gz"
+	chmod 444 "$(DESTDIR)$(PREFIX)/share/man/man1/e9patch.1.gz"
+	gzip --stdout doc/e9tool.1 > "$(DESTDIR)$(PREFIX)/share/man/man1/e9tool.1.gz"
+	chmod 444 "$(DESTDIR)$(PREFIX)/share/man/man1/e9tool.1.gz"
+	gzip --stdout doc/e9compile.1 > "$(DESTDIR)$(PREFIX)/share/man/man1/e9compile.1.gz"
+	chmod 444 "$(DESTDIR)$(PREFIX)/share/man/man1/e9compile.1.gz"
 
 #########################################################################
 # SPECIAL BUILD


### PR DESCRIPTION
Conventionally PREFIX falls back to /usr/local (so users don't mix up distro-provided packages with manually compiled ones) but it's kept as /usr here for backward compatibility.