### PR TITLE
Set expected file mode in test to 644

### DIFF
--- a/test/regtest/stat.exp
+++ b/test/regtest/stat.exp
@@ -1,3 +1,3 @@
-mode = 100664
+mode = 100644
 size = 62
 PASSED


### PR DESCRIPTION
For real files, git only distinguish between executable or not, and the mode of a checked-out file is either 644 or 755.