### PR TITLE
Remove executable bits from e9compiled binary

### DIFF
--- a/e9compile.sh
+++ b/e9compile.sh
@@ -139,5 +139,4 @@ then
     fi
 fi
 
-exit 0
-
+chmod a-x "$BASENAME"


### PR DESCRIPTION
At the end of the shell script, exit 0 is removed as it does not do anything useful.