### PR TITLE
Fix same_op_2 test expectation

### DIFF
--- a/test/regtest/same_op_2.exp
+++ b/test/regtest/same_op_2.exp
@@ -12,6 +12,7 @@ shl $0x7, %rdi
 sar $0x3, %rdi
 pxor %xmm0, %xmm0
 cvtsi2ss %rax, %xmm0
+sqrtss %xmm0, %xmm1
 xor %esi, %esi
 xor %eax, %eax
 PASSED


### PR DESCRIPTION
For convenient reference, `same_op_2` prints instructions matching `src[1] == dst[0]`.