### PR TITLE
Remove use of GNU make's secondary expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 .PHONY: all clean install dev release debug sanitize
-.SECONDEXPANSION:
 
 #########################################################################
 # BUILD COMMON


### PR DESCRIPTION
This GNU-specific extension was introduced in 29dc57d59e1f ("Allow linking to system Zydis") and its use was removed in 70d605e03905 ("Fix Makefile for build.sh").