### PR TITLE
Fix incorrect RIP-relative detection logic and `mmap()` parameter order

### DIFF
--- a/src/e9patch/e9CFR.cpp
+++ b/src/e9patch/e9CFR.cpp
@@ -241,7 +241,7 @@ void targetAnalysis(Binary *B)
                     uint8_t modRM = data[j+2];
                     uint8_t mod = (modRM & 0xc0) >> 6;
                     uint8_t rm  = modRM & 0x7;
-                    if (mod != 0x00 && rm != 0x05)
+                    if (mod != 0x00 || rm != 0x05)
                         continue;
                     target = j + 7 + *(int32_t *)(data + j + 3);
                     if (target >= 0 && target % sizeof(int32_t) == 0)

--- a/src/e9tool/e9frontend.cpp
+++ b/src/e9tool/e9frontend.cpp
@@ -895,7 +895,7 @@ ELF *e9tool::parseELF(const char *filename, intptr_t base)
             strerror(errno));
 
     size_t size = (size_t)stat.st_size;
-    void *ptr = mmap(NULL, size, MAP_SHARED, PROT_READ, fd, 0);
+    void *ptr = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
     if (ptr == MAP_FAILED)
         error("failed to map file \"%s\" into memory: %s", filename,
             strerror(errno));
@@ -1355,7 +1355,7 @@ ELF *e9tool::parsePE(const char *filename)
             strerror(errno));
 
     size_t size = (size_t)stat.st_size;
-    void *ptr = mmap(NULL, size, MAP_SHARED, PROT_READ, fd, 0);
+    void *ptr = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
     if (ptr == MAP_FAILED)
         error("failed to map file \"%s\" into memory: %s", filename,
             strerror(errno));


### PR DESCRIPTION
d03f658a: The code is checking for RIP-relative addressing (mod==0x00 AND rm==0x05). The original condition (mod != 0x00 && rm != 0x05) incorrectly applied De Morgan's law, causing false positives.

Correct De Morgan's: `!(A && B) = !A || !B`
Changed to: `(mod != 0x00 || rm != 0x05)`


8cdd39d8: The 3rd and 4th arguments to mmap() were in wrong order. POSIX signature: `mmap(addr, length, prot, flags, fd, offset)`